### PR TITLE
Fix GitHub Actions default branch runs

### DIFF
--- a/.github/workflows/beta-unittests.yml
+++ b/.github/workflows/beta-unittests.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - master
+      - main
       - "test/**" # Push events to branches matching refs/heads/test/[ANYTHING]
       - "test-*" # Push events to branches matching refs/heads/test-[ANYTHING]
   pull_request:

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - master
+      - main
       - "test/**" # Push events to branches matching refs/heads/test/[ANYTHING]
       - "test-*" # Push events to branches matching refs/heads/test-[ANYTHING]
   pull_request:

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - master
+      - main
       - "test/**" # Push events to branches matching refs/heads/test/[ANYTHING]
       - "test-*" # Push events to branches matching refs/heads/test-[ANYTHING]
   pull_request:

--- a/.github/workflows/stable-unittests.yml
+++ b/.github/workflows/stable-unittests.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - master
+      - main
       - "test/**" # Push events to branches matching refs/heads/test/[ANYTHING]
       - "test-*" # Push events to branches matching refs/heads/test-[ANYTHING]
   pull_request:


### PR DESCRIPTION
Default branch is `main`, not `master`.  This updates the configurations so that the workflows execute on default branch pushes