### PR TITLE
Add optional custom UFO out path appended names and extensions

### DIFF
--- a/src/lib/formatters.rs
+++ b/src/lib/formatters.rs
@@ -66,12 +66,13 @@ mod tests {
                 );
             }
         }
+        assert!(!invalid_path.exists());
     }
 
     #[test]
     fn test_format_ufo_invalid_dir_path_with_custom_names() {
         let invalid_path = Path::new("totally/bogus/path/test.ufo");
-        let res = format_ufo(invalid_path, &Some("test".to_string()), &Some(".test".to_string()));
+        let res = format_ufo(invalid_path, &Some("_new".to_string()), &Some(".test".to_string()));
         assert!(res.is_err());
         match res {
             Ok(x) => panic!("failed with unexpected test result: {:?}", x),
@@ -82,6 +83,8 @@ mod tests {
                 );
             }
         }
+        let new_path = Path::new("totally/bogus/path/test_new.test");
+        assert!(!new_path.exists());
     }
 
     #[test]
@@ -100,6 +103,7 @@ mod tests {
         let res_ufo_format = format_ufo(&test_ufo_path, &None, &None);
         assert!(res_ufo_format.is_ok());
         assert_eq!(format!("{:?}", res_ufo_format.unwrap()), format!("{:?}", &test_ufo_path));
+        assert!(&test_ufo_path.exists());
 
         Ok(())
     }

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -1,3 +1,4 @@
 pub mod errors;
 pub mod formatters;
+pub mod utils;
 pub mod validators;

--- a/src/lib/utils.rs
+++ b/src/lib/utils.rs
@@ -8,7 +8,7 @@ pub(crate) fn get_ufo_outpath(
 ) -> PathBuf {
     let original_basepath = match user_ufo_path.parent() {
         Some(opar) => opar,
-        None => &Path::new("."),
+        None => Path::new("."),
     };
 
     let new_basepath = PathBuf::from(original_basepath);
@@ -27,14 +27,14 @@ pub(crate) fn get_ufo_outpath(
 
     let original_extension = match user_ufo_path.extension() {
         Some(oext) => oext,
-        None => &OsStr::new(""),
+        None => OsStr::new(""),
     };
 
     match user_unique_extension {
         Some(unique_ext) => {
             // create the new extension string
             if unique_ext.starts_with('.') {
-                new_outpath.set_extension(unique_ext.strip_prefix(".").unwrap())
+                new_outpath.set_extension(unique_ext.strip_prefix('.').unwrap())
             } else {
                 new_outpath.set_extension(unique_ext)
             }

--- a/src/lib/utils.rs
+++ b/src/lib/utils.rs
@@ -1,0 +1,105 @@
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
+
+pub(crate) fn get_ufo_outpath(
+    user_ufo_path: &Path,
+    user_unique_filename: &Option<String>,
+    user_unique_extension: &Option<String>,
+) -> PathBuf {
+    let original_basepath = match user_ufo_path.parent() {
+        Some(opar) => opar,
+        None => &Path::new("."),
+    };
+
+    let new_basepath = PathBuf::from(original_basepath);
+
+    let original_dir_rootpath = match user_ufo_path.file_stem() {
+        Some(oroot) => oroot,
+        None => panic!("missing directory root!"),
+    };
+
+    let mut new_outpath = match user_unique_filename {
+        Some(unique_name) => {
+            new_basepath.join(format!("{}{}", original_dir_rootpath.to_string_lossy(), unique_name))
+        }
+        None => new_basepath.join(original_dir_rootpath),
+    };
+
+    let original_extension = match user_ufo_path.extension() {
+        Some(oext) => oext,
+        None => &OsStr::new(""),
+    };
+
+    match user_unique_extension {
+        Some(unique_ext) => {
+            // create the new extension string
+            if unique_ext.starts_with('.') {
+                new_outpath.set_extension(unique_ext.strip_prefix(".").unwrap())
+            } else {
+                new_outpath.set_extension(unique_ext)
+            }
+        }
+        None => new_outpath.set_extension(original_extension),
+    };
+
+    new_outpath
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_ufo_outpath_default() {
+        let op = get_ufo_outpath(&Path::new("one/two/three.ufo"), &None, &None);
+        assert_eq!(op, PathBuf::from("one/two/three.ufo"));
+    }
+
+    #[test]
+    fn test_get_ufo_path_unique_filename() {
+        let op = get_ufo_outpath(&Path::new("one/two/three.ufo"), &Some("-new".to_string()), &None);
+        assert_eq!(op, PathBuf::from("one/two/three-new.ufo"));
+    }
+
+    #[test]
+    fn test_get_ufo_path_unique_extension_two_extensions_withperiod() {
+        let op =
+            get_ufo_outpath(&Path::new("one/two/three.ufo"), &None, &Some(".fmt.ufo".to_string()));
+        assert_eq!(op, PathBuf::from("one/two/three.fmt.ufo"));
+    }
+
+    #[test]
+    fn test_get_ufo_path_unique_extension_two_extensions_without_period() {
+        let op =
+            get_ufo_outpath(&Path::new("one/two/three.ufo"), &None, &Some("fmt.ufo".to_string()));
+        assert_eq!(op, PathBuf::from("one/two/three.fmt.ufo"));
+    }
+
+    #[test]
+    fn test_get_ufo_path_unique_extension_single_extension_with_period() {
+        let op = get_ufo_outpath(&Path::new("one/two/three.ufo"), &None, &Some(".fmt".to_string()));
+        assert_eq!(op, PathBuf::from("one/two/three.fmt"));
+    }
+
+    #[test]
+    fn test_get_ufo_path_unique_extension_single_extension_without_period() {
+        let op = get_ufo_outpath(&Path::new("one/two/three.ufo"), &None, &Some("fmt".to_string()));
+        assert_eq!(op, PathBuf::from("one/two/three.fmt"));
+    }
+
+    #[test]
+    fn test_get_ufo_path_unique_extension_empty_extension() {
+        let op = get_ufo_outpath(&Path::new("one/two/three.ufo"), &None, &Some("".to_string()));
+        assert_eq!(op, PathBuf::from("one/two/three"));
+    }
+
+    #[test]
+    fn test_get_ufo_path_unique_extension_unique_dirname() {
+        let op = get_ufo_outpath(
+            &Path::new("one/two/three.ufo"),
+            &Some("-new".to_string()),
+            &Some("fmt".to_string()),
+        );
+        assert_eq!(op, PathBuf::from("one/two/three-new.fmt"));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,7 @@
 //!
 //! Enter `ufofmt --help` to view help documentation with all available command line options.
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::time::Instant;
 
 use rayon::prelude::*;
@@ -53,6 +53,22 @@ struct Opt {
     #[structopt(short = "t", long = "time", help = "Display timing data")]
     time: bool,
 
+    /// Define a unique directory write path extension
+    #[structopt(
+        name = "UNIQUE_EXTENSION",
+        long = "out-ext",
+        help = "Define a unique directory write path extension"
+    )]
+    uniqueext: Option<String>,
+
+    /// Append a unique directory write path name before the extension
+    #[structopt(
+        name = "UNIQUE_FILENAME_STRING",
+        long = "out-name",
+        help = "Append a unique directory write path name before the extension"
+    )]
+    uniquename: Option<String>,
+
     /// UFO source file paths
     #[structopt(help = "UFO source path(s)")]
     ufopaths: Vec<PathBuf>,
@@ -65,8 +81,11 @@ fn main() {
     // Source formatting execution
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~
     let now = Instant::now();
-    let results: Vec<errors::Result<&Path>> =
-        argv.ufopaths.par_iter().map(|ufopath| formatters::format_ufo(ufopath)).collect();
+    let results: Vec<errors::Result<PathBuf>> = argv
+        .ufopaths
+        .par_iter()
+        .map(|ufopath| formatters::format_ufo(ufopath, &argv.uniquename, &argv.uniqueext))
+        .collect();
     let duration = now.elapsed().as_millis();
 
     for result in &results {


### PR DESCRIPTION
Closes #10 

Adds two new command line options that are not mutually exclusive:

- `--out-name`: takes a string argument that is appended to the base UFO dir path name(s) before the `.ufo` extension
  -  `--out-name _FMT` ==> `somepath_FMT.ufo`
- `--out-ext`: takes a string argument that replaces the .ufo extension on the UFO dir paths.
  - `--out-ext FMT.ufo` ==> `somepath.FMT.ufo`

The executable accepts multiple UFO directory path requests and supports parallel execution when multiple paths are requested.  You want to use multiple dir path args when you need to process multiple UFO dirs with this tool.  Multiple dir processing limits full base dir name replacements from the command line.  This approach allows a user to modify parts of the inpath to support writes on different paths as an alternative to the in-place write default.